### PR TITLE
Fix codecs errors on cyrillic windows

### DIFF
--- a/telegram_json_to_vcf.py
+++ b/telegram_json_to_vcf.py
@@ -71,13 +71,13 @@ if os.path.isfile(vcf_file):
 
 
 try:
-    cts = json.load(open(json_file))
+    cts = json.load(open(json_file, encoding='utf8'))
     cts = cts["contacts"]["list"]
 except Exception as err:
     raise RuntimeError("An unexpected error happened!") from err
 
 
-with open(vcf_file, "w") as f:
+with open(vcf_file, "w", encoding='utf8') as f:
     for ct in cts:
         fname = ct["first_name"]
         lname = ct["last_name"]


### PR DESCRIPTION
Fix issues with incorrect utf-8 decoding on cyrillic windows and possible on another locales:
Traceback (most recent call last):
File "telegram_json_to_vcf.py", line 75, in
cts = json.load(open(json_file))
File "C:\Python3\lib\json_init_.py", line 293, in load
return loads(fp.read(),
File "C:\Python3\lib\encodings\cp1251.py", line 23, in decode
return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 7989: character maps to